### PR TITLE
RFC: prune completed transactions from queues

### DIFF
--- a/src/mgopurge/machines.go
+++ b/src/mgopurge/machines.go
@@ -4,10 +4,7 @@
 package main
 
 import (
-	"fmt"
-
 	"gopkg.in/mgo.v2"
-	"gopkg.in/mgo.v2/bson"
 )
 
 // FixMachinesTxnQueue removes txn-queue field errors for machine
@@ -15,50 +12,8 @@ import (
 // problem with the machine address updater in historical juju
 // versions which resulted in runaway txn-queue fields.
 func FixMachinesTxnQueue(machines, tc *mgo.Collection) error {
-	completed := make(map[bson.ObjectId]bool)
-	txnCompleted := func(txnId bson.ObjectId) bool {
-		complete, found := completed[txnId]
-		if found {
-			return complete
-		}
-		q := tc.Find(bson.M{
-			"_id": txnId,
-			"s":   bson.M{"$in": []int{5, 6}},
-		})
-		complete = q.One(nil) == nil
-		completed[txnId] = complete
-		return complete
-	}
-
-	type TDoc struct {
-		Id       interface{}   "_id"
-		TxnQueue []interface{} "txn-queue"
-	}
-
-	iter := machines.Find(nil).Select(bson.M{"_id": 1, "txn-queue": 1}).Iter()
-	var doc TDoc
-	machineCount := 0
-	for iter.Next(&doc) {
-		var pullTokens []interface{}
-		for _, txnToken := range doc.TxnQueue {
-			if txnId, ok := tokenToId(txnToken); ok {
-				if txnCompleted(txnId) {
-					pullTokens = append(pullTokens, txnToken)
-				}
-			}
-		}
-		if len(pullTokens) > 0 {
-			err := machines.UpdateId(doc.Id, bson.M{"$pullAll": bson.M{"txn-queue": pullTokens}})
-			if err != nil {
-				return err
-			}
-			logger.Debugf("machine %s: removed %d txn-queue entries", doc.Id, len(pullTokens))
-		}
-		machineCount++
-	}
-	if err := iter.Close(); err != nil {
-		return fmt.Errorf("machines iteration error: %v", err)
-	}
-	logger.Infof("Finished checking %d machine documents", machineCount)
-	return nil
+	oracle := NewTXNOracle(tc)
+	err := FixCollectionTxnQueue(machines, oracle)
+	logger.Infof("%s", oracle.Describe())
+	return err
 }

--- a/src/mgopurge/main.go
+++ b/src/mgopurge/main.go
@@ -30,10 +30,10 @@ related problems in a Juju database. Casual use is strongly
 discouraged. Irreversible damage may be caused to a Juju deployment
 through improper use of this tool.
 
-This program should not be run while any Juju controller machine
-agents are running.
+Aside from limited cases, this program should not be run while Juju
+controller machine agents are running.
 
-Have all controller machine agents been shut down?`[1:]
+Ok to proceed?`[1:]
 
 // allStages defines all of mgopurge's stages. As some stages must be
 // run before others, the ordering is important.

--- a/src/mgopurge/main.go
+++ b/src/mgopurge/main.go
@@ -58,6 +58,12 @@ var allStages = []stage{
 			return FixMachinesTxnQueue(db.C(machinesC), txns)
 		},
 	}, {
+		"prunequeues",
+		"Remove references to completed transactions in all collections",
+		func(db *mgo.Database, txns *mgo.Collection) error {
+			return PruneAllCollectionQueues(db, txns)
+		},
+	}, {
 		"prune",
 		"Prune unreferenced transactions",
 		func(db *mgo.Database, txns *mgo.Collection) error {

--- a/src/mgopurge/prune_completed.go
+++ b/src/mgopurge/prune_completed.go
@@ -80,7 +80,10 @@ func CollectionsToPruneQueues(db *mgo.Database, txnsName string) ([]string, erro
 		include := true
 		switch {
 		case name == txnsName+".stash":
-			include = true
+			// We don't include pruning txns.stash entries because those are
+			// things that should really not be considered completed, if they
+			// are in the stash they are going to be deleted or created
+			include = false
 		case name == txnsName, strings.HasPrefix(name, txnsName+"."):
 			// Don't look in things other than txns.stash that are related to txns
 			include = false

--- a/src/mgopurge/prune_completed.go
+++ b/src/mgopurge/prune_completed.go
@@ -1,0 +1,166 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type TxnCompleted interface {
+	IsCompleted(txnId bson.ObjectId) bool
+}
+
+type txnOracle struct {
+	Completed      map[bson.ObjectId]bool
+	TxnsCollection *mgo.Collection
+	HitCount       uint64
+	QueryCount     uint64
+	CompleteCount  uint64
+	IncompleteCount uint64
+}
+
+type txnStatus struct {
+	Status int `bson:"s"`
+}
+func (oracle *txnOracle) IsCompleted(txnId bson.ObjectId) bool {
+	oracle.QueryCount++
+	complete, found := oracle.Completed[txnId]
+	if found {
+		oracle.HitCount++
+		return complete
+	}
+	var st txnStatus
+	q := oracle.TxnsCollection.Find(bson.M{"_id": txnId}).Select(bson.M{"_id": 0, "s": 1})
+	err := q.One(&st)
+	complete = false
+	if err == nil {
+		// Not found is treated as not-complete for our purposes
+		complete = (st.Status == 5 || st.Status == 6)
+	}
+	oracle.Completed[txnId] = complete
+	if complete {
+		oracle.CompleteCount++
+	} else {
+		oracle.IncompleteCount++
+	}
+	return complete
+}
+
+func (oracle *txnOracle) Describe() string {
+	hitRate := 0.0
+	if oracle.QueryCount > 0 {
+		hitRate = (float64(oracle.HitCount) * 100.0 / float64(oracle.QueryCount))
+	}
+	return fmt.Sprintf("Oracle HitCount %d, QueryCount %d, HitRate %.1f%%, Completed: %d, Incomplete: %d",
+		oracle.HitCount, oracle.QueryCount, hitRate,
+		oracle.CompleteCount, oracle.IncompleteCount)
+}
+
+func NewTXNOracle(coll *mgo.Collection) *txnOracle {
+	return &txnOracle{
+		Completed:      make(map[bson.ObjectId]bool),
+		TxnsCollection: coll,
+	}
+}
+
+// CollectionsToPruneQueues finds collection names that we should process for
+// txn-queue fields.
+func CollectionsToPruneQueues(db *mgo.Database, txnsName string) ([]string, error) {
+	collNames, err := db.CollectionNames()
+	if err != nil {
+		return nil, fmt.Errorf("reading collection names: %v", err)
+	}
+	outNames := make([]string, 0, len(collNames))
+	for _, name := range collNames {
+		include := true
+		switch {
+		case name == txnsName+".stash":
+			include = true
+		case name == txnsName, strings.HasPrefix(name, txnsName+"."):
+			// Don't look in things other than txns.stash that are related to txns
+			include = false
+		case strings.HasPrefix(name, "system."):
+			// Don't look in system collections.
+			include = false
+		default:
+			// Everything else needs to be considered.
+			include = true
+		}
+		if include {
+			outNames = append(outNames, name)
+		}
+	}
+	return outNames, nil
+}
+
+// PruneAllCollectionQueues iterates through all known databases and looks for
+// transactions that should be considered completed.
+func PruneAllCollectionQueues(db *mgo.Database, txns *mgo.Collection) error {
+	names, err := CollectionsToPruneQueues(db, txns.Name)
+	if err != nil {
+		return err
+	}
+	logger.Infof("%d collections to prune queues", len(names))
+	oracle := NewTXNOracle(txns)
+	for _, name := range names {
+		logger.Infof("pruning queues in collection %q", name)
+		coll := db.C(name)
+		err := FixCollectionTxnQueue(coll, oracle)
+		logger.Infof("%s", oracle.Describe())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// FixCollectionTxnQueue removes txn-queue field errors for machine
+// documents which refer to completed transactions. This addresses a
+// problem with the machine address updater in historical juju
+// versions which resulted in runaway txn-queue fields.
+func FixCollectionTxnQueue(coll *mgo.Collection, oracle TxnCompleted) error {
+
+	type TDoc struct {
+		Id       interface{}   "_id"
+		TxnQueue []interface{} "txn-queue"
+	}
+
+	query := coll.Find(nil).Select(bson.M{"_id": 1, "txn-queue": 1})
+	query.Batch(100)
+	iter := query.Iter()
+	var doc TDoc
+	docCount := 0
+	totalPulled := 0
+	for iter.Next(&doc) {
+		var pullTokens []interface{}
+		for _, txnToken := range doc.TxnQueue {
+			if txnId, ok := tokenToId(txnToken); ok {
+				if oracle.IsCompleted(txnId) {
+					pullTokens = append(pullTokens, txnToken)
+				}
+			}
+		}
+		if len(pullTokens) > 0 {
+			/// err := coll.UpdateId(doc.Id, bson.M{"$pullAll": bson.M{"txn-queue": pullTokens}})
+			/// if err != nil {
+			/// 	return err
+			/// }
+			// We don't log everything because most objects will have at least 1 token
+			if len(pullTokens) > 1 {
+				logger.Debugf("%s %s: removed %d txn-queue entries", coll.Name, doc.Id, len(pullTokens))
+			}
+			totalPulled += len(pullTokens)
+		}
+		docCount++
+	}
+	if err := iter.Close(); err != nil {
+		return fmt.Errorf(" iteration error: %v", err)
+	}
+	logger.Infof("Finished checking %d %s documents, pulled %d entries", docCount, coll.Name, totalPulled)
+	return nil
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -10,7 +10,7 @@
 		{
 			"importpath": "github.com/juju/txn",
 			"repository": "https://github.com/juju/txn",
-			"revision": "28898197906200d603394d8e4ce537436529f1c5",
+			"revision": "b0486f90a44540ef9a5cfc9f3fad904832e954fe",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
This is an attempt to just iterate over all the existing documents and pull out all of the completed transactions.

*Right* now the actual pruning is disabled because I wanted to see what it would do.

One thing about the production DB is that it has 300k items in the transactions stash, all of which appear to have 2 transactions on them. From what I can tell, they follow the pattern of "txn1 marks it as dying, txn2 marks it as deleted", but both of them are still in the txn-queue by the time it ends up in the stash, and then nothing ever reaps them from the stash.

So I'd like us to figure out what to do with the stash items. I *think* we can use "if all txns on a stash item are completed, delete the item from the stash". Or we can use the same algorithm for purging all completed txns, and then iterate over the txns.stash and remove any items that aren't participating in any transactions.

As for whether we can remove the last item from the queue, I think it is fine. I think the only reason Flush doesn't do it directly is because it can't do it until it has updated all documents, and it doesn't want to go across all documents yet-another-time.