### PR TITLE
Compact a database named 'logs' when we are compacting the Juju database

### DIFF
--- a/src/mgopurge/main.go
+++ b/src/mgopurge/main.go
@@ -77,7 +77,16 @@ var allStages = []stage{
 		"compact",
 		"Compact database to release disk space (does not compact replicas)",
 		func(db *mgo.Database, _ *mgo.Collection) error {
-			return compact(db)
+			err := compact(db)
+			if err != nil {
+				return err
+			}
+			logsDB := db.Session.DB("logs")
+			err = compact(logsDB)
+			if err != nil {
+				return err
+			}
+			return nil
 		},
 	},
 }


### PR DESCRIPTION
To handle issue #15.

This just adds a compact pass over the 'logs' database when we're doing the compact over the 'juju' database.
