### PR TITLE
Trim long queues

### DIFF
--- a/src/mgopurge/main.go
+++ b/src/mgopurge/main.go
@@ -54,6 +54,13 @@ var allStages = []stage{
 			return PurgeMissing(txns, db.C(txnsStashC), collections...)
 		},
 	}, {
+		"trim",
+		"Trim txn-queues that are longer than 10000",
+		func(db *mgo.Database, txns *mgo.Collection) error {
+			collections := getAllPurgeableCollections(db)
+			return TrimLongTransactionQueues(txns, collections...)
+		},
+	}, {
 		"resume",
 		"Resume incomplete transactions",
 		func(db *mgo.Database, txns *mgo.Collection) error {

--- a/src/mgopurge/main.go
+++ b/src/mgopurge/main.go
@@ -64,7 +64,7 @@ var allStages = []stage{
 		"Prune finalised transactions",
 		func(db *mgo.Database, txns *mgo.Collection) error {
 			stats, err := jujutxn.CleanAndPrune(jujutxn.CleanAndPruneArgs{
-				Txns: txns,
+				Txns:    txns,
 				MaxTime: time.Now().Add(-time.Hour),
 			})
 			logger.Infof("clean and prune cleaned %d docs in %d collections\n"+

--- a/src/mgopurge/trim.go
+++ b/src/mgopurge/trim.go
@@ -1,0 +1,178 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package main
+
+import (
+	"time"
+
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// txnDoc is a document that has interesting transactions we want to investigate
+type txnDoc struct {
+	Id       interface{}   "_id"
+	TxnQueue []interface{} "txn-queue"
+}
+
+const (
+	tpreparing int = 1 // One or more documents not prepared
+	tprepared  int = 2 // Prepared but not yet ready to run
+)
+
+type rawTransaction struct {
+	Id    bson.ObjectId `bson:"_id"`
+	State int           `bson:"s"`
+	Ops   []txn.Op      `bson:"o"`
+	Nonce string        `bson:"n,omitempty"`
+}
+
+func iterDocsWithLongQueues(coll *mgo.Collection) (*mgo.Iter, error) {
+	query := coll.Find(bson.M{longTxnEntry: bson.M{"exists": 1}}).Select(bson.M{"txn-queue": 1, "_id": 1})
+	return query.Iter(), nil
+}
+
+func tokenToIdNonce(token interface{}) (bson.ObjectId, string, bool) {
+	tokenStr, ok := token.(string)
+	if !ok {
+		return "", "", false
+	}
+	if !validToken.MatchString(tokenStr) {
+		return "", "", false
+	}
+	// take the first 24 hex chars as the object ID, and the last 8 chars as the nonce
+	return bson.ObjectIdHex(tokenStr[:24]), tokenStr[26:], true
+}
+
+// txnBatchSize is how many transactions we will Remove() at a time
+const txnBatchSize = 5000
+
+// longTxnEntry existing means we have a txn-queue with at least 10,000 items
+const longTxnEntry = "txn-queue.10000"
+
+func findTxnsToRemove(doc txnDoc, coll, txns *mgo.Collection) ([]bson.ObjectId, []interface{}, error) {
+	txnsToRemove := make([]bson.ObjectId, 0, len(doc.TxnQueue))
+	tokensToPull := make([]interface{}, 0, len(doc.TxnQueue))
+	for _, token := range doc.TxnQueue {
+		txnId, nonce, valid := tokenToIdNonce(token)
+		if !valid {
+			// Shouldn't happen, at a minimum PurgeMissing should have removed it
+			logger.Warningf("%q document %q has invalid token: %v",
+				coll.Name, doc.Id, token)
+			continue
+		}
+		var txn rawTransaction
+		if err := txns.FindId(txnId).One(&txn); err != nil {
+			// Shouldn't happen (again PurgeMissing)
+			logger.Warningf("%q document %q has missing transaction: %v",
+				coll.Name, doc.Id, token)
+		}
+		if txn.State != tpreparing && txn.State != tprepared {
+			// We only prune out prepared/preparing txns
+			continue
+		}
+		// We are extra conservative about the type of transactions we will
+		// prune. For now, we will only prune transactions that only involve this document.
+		if len(txn.Ops) != 1 {
+			continue
+		}
+		op := txn.Ops[0]
+		if op.C != coll.Name || op.Id != doc.Id {
+			continue
+		}
+		if nonce == txn.Nonce {
+			// This transaction involves exactly this document,
+			// queue it for removal
+			txnsToRemove = append(txnsToRemove, txnId)
+		}
+		// This token is for a transaction that should be removed, we
+		// can remove the token even if the nonce isn't exactly the same,
+		// because the one with the right nonce should also be present
+		tokensToPull = append(tokensToPull, token)
+	}
+	return txnsToRemove, tokensToPull, nil
+}
+
+func removeTransactions(txns *mgo.Collection, txnsToRemove []bson.ObjectId, timer *simpleTimer, removedCount int) (int, error) {
+	for len(txnsToRemove) > 0 {
+		batch := txnsToRemove
+		if len(batch) > txnBatchSize {
+			batch = batch[:txnBatchSize]
+		}
+		txnsToRemove = txnsToRemove[len(batch):]
+		info, err := txns.RemoveAll(bson.M{"_id": bson.M{"$in": batch}})
+		if err != nil {
+			return removedCount, err
+		}
+		removedCount += info.Removed
+		if timer.isAfter() {
+			logger.Debugf("removed %d txns from %s", txns.Name)
+		}
+	}
+	return removedCount, nil
+}
+
+func TrimLongTransactionQueues(txns *mgo.Collection, collNames ...string) error {
+	txnsRemovedCount := 0
+	tokensPulledCount := 0
+	docCleanupCount := 0
+	tStart := time.Now()
+	timer := newSimpleTimer(15 * time.Second)
+	for _, collName := range collNames {
+		coll := txns.Database.C(collName)
+		iter, err := iterDocsWithLongQueues(coll)
+		if err != nil {
+			return err
+		}
+		var doc txnDoc
+		for iter.Next(&doc) {
+			docCleanupCount++
+			logger.Infof("%q document %q has %d transactions",
+				coll.Name, doc.Id, len(doc.TxnQueue))
+			txnsToRemove, tokensToPull, err := findTxnsToRemove(doc, coll, txns)
+			if err != nil {
+				return err
+			}
+			// We remove the transactions from the txn collection before we remove them
+			// from the document, because PurgeMissing will handle removing them from
+			// the document if we fail midway. But anything in 'prepared'+ state is
+			// presumed to still be referenced in the document.
+			txnsRemovedCount, err = removeTransactions(txns, txnsToRemove, timer, txnsRemovedCount)
+			if err != nil {
+				return err
+			}
+			if err := pullTokens(coll, doc.Id, tokensToPull); err != nil {
+				return err
+			}
+			tokensPulledCount += len(tokensToPull)
+		}
+		if err := iter.Close(); err != nil {
+			return err
+		}
+	}
+	logger.Infof("cleaned up %d docs from %d tokens, removing %d transactions in %v",
+		docCleanupCount, tokensPulledCount, txnsRemovedCount, time.Since(tStart))
+	return nil
+}
+
+func newSimpleTimer(interval time.Duration) *simpleTimer {
+	return &simpleTimer{
+		interval: interval,
+		next:     time.Now().Add(interval),
+	}
+}
+
+type simpleTimer struct {
+	interval time.Duration
+	next     time.Time
+}
+
+func (t *simpleTimer) isAfter() bool {
+	now := time.Now()
+	if now.After(t.next) {
+		t.next = now.Add(t.interval)
+		return true
+	}
+	return false
+}

--- a/vendor/src/gopkg.in/check.v1/benchmark.go
+++ b/vendor/src/gopkg.in/check.v1/benchmark.go
@@ -1,9 +1,9 @@
 // Copyright (c) 2012 The Go Authors. All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 //    * Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
 //    * Redistributions in binary form must reproduce the above
@@ -13,7 +13,7 @@
 //    * Neither the name of Google Inc. nor the names of its
 // contributors may be used to endorse or promote products derived from
 // this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR

--- a/vendor/src/gopkg.in/check.v1/benchmark_test.go
+++ b/vendor/src/gopkg.in/check.v1/benchmark_test.go
@@ -3,8 +3,8 @@
 package check_test
 
 import (
-	"time"
 	. "gopkg.in/check.v1"
+	"time"
 )
 
 var benchmarkS = Suite(&BenchmarkS{})

--- a/vendor/src/gopkg.in/check.v1/printer_test.go
+++ b/vendor/src/gopkg.in/check.v1/printer_test.go
@@ -1,7 +1,7 @@
 package check_test
 
 import (
-    .   "gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
 )
 
 var _ = Suite(&PrinterS{})
@@ -9,96 +9,101 @@ var _ = Suite(&PrinterS{})
 type PrinterS struct{}
 
 func (s *PrinterS) TestCountSuite(c *C) {
-    suitesRun += 1
+	suitesRun += 1
 }
 
 var printTestFuncLine int
 
 func init() {
-    printTestFuncLine = getMyLine() + 3
+	printTestFuncLine = getMyLine() + 3
 }
 
 func printTestFunc() {
-    println(1)           // Comment1
-    if 2 == 2 {          // Comment2
-        println(3)       // Comment3
-    }
-    switch 5 {
-    case 6: println(6)   // Comment6
-        println(7)
-    }
-    switch interface{}(9).(type) {// Comment9
-    case int: println(10)
-        println(11)
-    }
-    select {
-    case <-(chan bool)(nil): println(14)
-        println(15)
-    default: println(16)
-        println(17)
-    }
-    println(19,
-        20)
-    _ = func() { println(21)
-        println(22)
-    }
-    println(24, func() {
-        println(25)
-    })
-    // Leading comment
-    // with multiple lines.
-    println(29)  // Comment29
+	println(1)  // Comment1
+	if 2 == 2 { // Comment2
+		println(3) // Comment3
+	}
+	switch 5 {
+	case 6:
+		println(6) // Comment6
+		println(7)
+	}
+	switch interface{}(9).(type) { // Comment9
+	case int:
+		println(10)
+		println(11)
+	}
+	select {
+	case <-(chan bool)(nil):
+		println(14)
+		println(15)
+	default:
+		println(16)
+		println(17)
+	}
+	println(19,
+		20)
+	_ = func() {
+		println(21)
+		println(22)
+	}
+	println(24, func() {
+		println(25)
+	})
+	// Leading comment
+	// with multiple lines.
+	println(29) // Comment29
 }
 
 var printLineTests = []struct {
-    line   int
-    output string
+	line   int
+	output string
 }{
-    {1, "println(1) // Comment1"},
-    {2, "if 2 == 2 { // Comment2\n    ...\n}"},
-    {3, "println(3) // Comment3"},
-    {5, "switch 5 {\n...\n}"},
-    {6, "case 6:\n    println(6) // Comment6\n    ..."},
-    {7, "println(7)"},
-    {9, "switch interface{}(9).(type) { // Comment9\n...\n}"},
-    {10, "case int:\n    println(10)\n    ..."},
-    {14, "case <-(chan bool)(nil):\n    println(14)\n    ..."},
-    {15, "println(15)"},
-    {16, "default:\n    println(16)\n    ..."},
-    {17, "println(17)"},
-    {19, "println(19,\n    20)"},
-    {20, "println(19,\n    20)"},
-    {21, "_ = func() {\n    println(21)\n    println(22)\n}"},
-    {22, "println(22)"},
-    {24, "println(24, func() {\n    println(25)\n})"},
-    {25, "println(25)"},
-    {26, "println(24, func() {\n    println(25)\n})"},
-    {29, "// Leading comment\n// with multiple lines.\nprintln(29) // Comment29"},
+	{1, "println(1) // Comment1"},
+	{2, "if 2 == 2 { // Comment2\n    ...\n}"},
+	{3, "println(3) // Comment3"},
+	{5, "switch 5 {\n...\n}"},
+	{6, "case 6:\n    println(6) // Comment6\n    ..."},
+	{7, "println(7)"},
+	{9, "switch interface{}(9).(type) { // Comment9\n...\n}"},
+	{10, "case int:\n    println(10)\n    ..."},
+	{14, "case <-(chan bool)(nil):\n    println(14)\n    ..."},
+	{15, "println(15)"},
+	{16, "default:\n    println(16)\n    ..."},
+	{17, "println(17)"},
+	{19, "println(19,\n    20)"},
+	{20, "println(19,\n    20)"},
+	{21, "_ = func() {\n    println(21)\n    println(22)\n}"},
+	{22, "println(22)"},
+	{24, "println(24, func() {\n    println(25)\n})"},
+	{25, "println(25)"},
+	{26, "println(24, func() {\n    println(25)\n})"},
+	{29, "// Leading comment\n// with multiple lines.\nprintln(29) // Comment29"},
 }
 
 func (s *PrinterS) TestPrintLine(c *C) {
-    for _, test := range printLineTests {
-        output, err := PrintLine("printer_test.go", printTestFuncLine+test.line)
-        c.Assert(err, IsNil)
-        c.Assert(output, Equals, test.output)
-    }
+	for _, test := range printLineTests {
+		output, err := PrintLine("printer_test.go", printTestFuncLine+test.line)
+		c.Assert(err, IsNil)
+		c.Assert(output, Equals, test.output)
+	}
 }
 
 var indentTests = []struct {
-    in, out string
+	in, out string
 }{
-    {"", ""},
-    {"\n", "\n"},
-    {"a", ">>>a"},
-    {"a\n", ">>>a\n"},
-    {"a\nb", ">>>a\n>>>b"},
-    {" ", ">>> "},
+	{"", ""},
+	{"\n", "\n"},
+	{"a", ">>>a"},
+	{"a\n", ">>>a\n"},
+	{"a\nb", ">>>a\n>>>b"},
+	{" ", ">>> "},
 }
 
 func (s *PrinterS) TestIndent(c *C) {
-    for _, test := range indentTests {
-        out := Indent(test.in, ">>>")
-        c.Assert(out, Equals, test.out)
-    }
+	for _, test := range indentTests {
+		out := Indent(test.in, ">>>")
+		c.Assert(out, Equals, test.out)
+	}
 
 }

--- a/vendor/src/gopkg.in/check.v1/run_test.go
+++ b/vendor/src/gopkg.in/check.v1/run_test.go
@@ -400,7 +400,7 @@ func (s *RunS) TestStreamModeWithMiss(c *C) {
 // -----------------------------------------------------------------------
 // Verify that that the keep work dir request indeed does so.
 
-type WorkDirSuite struct {}
+type WorkDirSuite struct{}
 
 func (s *WorkDirSuite) Test(c *C) {
 	c.MkDir()
@@ -411,7 +411,7 @@ func (s *RunS) TestKeepWorkDir(c *C) {
 	runConf := RunConf{Output: &output, Verbose: true, KeepWorkDir: true}
 	result := Run(&WorkDirSuite{}, &runConf)
 
-	c.Assert(result.String(), Matches, ".*\nWORK=" + result.WorkDir)
+	c.Assert(result.String(), Matches, ".*\nWORK="+result.WorkDir)
 
 	stat, err := os.Stat(result.WorkDir)
 	c.Assert(err, IsNil)

--- a/vendor/src/gopkg.in/mgo.v2/bson/bson_test.go
+++ b/vendor/src/gopkg.in/mgo.v2/bson/bson_test.go
@@ -1055,7 +1055,7 @@ type inlineBadKeyMap struct {
 }
 type inlineUnexported struct {
 	M          map[string]interface{} ",inline"
-	unexported         ",inline"
+	unexported ",inline"
 }
 type unexported struct {
 	A int

--- a/vendor/src/gopkg.in/mgo.v2/internal/scram/scram.go
+++ b/vendor/src/gopkg.in/mgo.v2/internal/scram/scram.go
@@ -133,7 +133,7 @@ func (c *Client) Step(in []byte) bool {
 func (c *Client) step1(in []byte) error {
 	if len(c.clientNonce) == 0 {
 		const nonceLen = 6
-		buf := make([]byte, nonceLen + b64.EncodedLen(nonceLen))
+		buf := make([]byte, nonceLen+b64.EncodedLen(nonceLen))
 		if _, err := rand.Read(buf[:nonceLen]); err != nil {
 			return fmt.Errorf("cannot read random SCRAM-SHA-1 nonce from operating system: %v", err)
 		}

--- a/vendor/src/gopkg.in/mgo.v2/txn/mgo_test.go
+++ b/vendor/src/gopkg.in/mgo.v2/txn/mgo_test.go
@@ -2,8 +2,8 @@ package txn_test
 
 import (
 	"bytes"
-	"gopkg.in/mgo.v2"
 	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
 	"os/exec"
 	"time"
 )

--- a/vendor/src/gopkg.in/mgo.v2/txn/sim_test.go
+++ b/vendor/src/gopkg.in/mgo.v2/txn/sim_test.go
@@ -2,10 +2,10 @@ package txn_test
 
 import (
 	"flag"
+	. "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
-	. "gopkg.in/check.v1"
 	"math/rand"
 	"time"
 )

--- a/vendor/src/gopkg.in/mgo.v2/txn/tarjan_test.go
+++ b/vendor/src/gopkg.in/mgo.v2/txn/tarjan_test.go
@@ -2,8 +2,8 @@ package txn
 
 import (
 	"fmt"
-	"gopkg.in/mgo.v2/bson"
 	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type TarjanSuite struct{}

--- a/vendor/src/gopkg.in/tomb.v2/tomb.go
+++ b/vendor/src/gopkg.in/tomb.v2/tomb.go
@@ -1,10 +1,10 @@
 // Copyright (c) 2011 - Gustavo Niemeyer <gustavo@niemeyer.net>
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
+//
 //     * Redistributions of source code must retain the above copyright notice,
 //       this list of conditions and the following disclaimer.
 //     * Redistributions in binary form must reproduce the above copyright notice,
@@ -13,7 +13,7 @@
 //     * Neither the name of the copyright holder nor the names of its
 //       contributors may be used to endorse or promote products derived from
 //       this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,7 +32,7 @@
 // goroutine via its Go method, and then any tracked goroutine may call
 // the Go method again to create additional tracked goroutines at
 // any point.
-// 
+//
 // If any of the tracked goroutines returns a non-nil error, or the
 // Kill or Killf method is called by any goroutine in the system (tracked
 // or not), the tomb Err is set, Alive is set to false, and the Dying
@@ -82,7 +82,7 @@ type Tomb struct {
 
 var (
 	ErrStillAlive = errors.New("tomb: still alive")
-	ErrDying = errors.New("tomb: dying")
+	ErrDying      = errors.New("tomb: dying")
 )
 
 func (t *Tomb) init() {


### PR DESCRIPTION
Handle the specific case of documents that are touched very frequently.
The most recent cases involved transactions that touched a single document,
and caused their txn queue to get out of hand. This fix just makes it
so mgopurge handles very narrow transactions (affecting only the doc
in question), and removes those transactions and the tokens from the
document.

(There is a 'go fmt' that touches vendor, I can revert that if you would prefer)