### PR TITLE
Skip system.* tables during compact.

### DIFF
--- a/src/mgopurge/compact.go
+++ b/src/mgopurge/compact.go
@@ -6,6 +6,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -62,6 +63,9 @@ func compactAll(db *mgo.Database) error {
 		return fmt.Errorf("obtaining collection names: %v", err)
 	}
 	for _, name := range names {
+		if strings.HasPrefix(name, "system.") {
+			continue
+		}
 		logger.Infof("compacting %s", name)
 		err := db.Run(bson.D{
 			{"compact", name},


### PR DESCRIPTION
We skip them for things like Purge, and for some reason it started
failing on prod machines. We shouldn't be doing anything there ourselves
that they would really need to be compacted.
We could use isPurgeable, but really we *do* want to compact txns*

Fixes #21 