### PR TITLE
Support handling txns with long queues that involve inserts.

### DIFF
--- a/src/mgopurge/main.go
+++ b/src/mgopurge/main.go
@@ -22,7 +22,7 @@ import (
 
 const txnsC = "txns"
 const txnsStashC = txnsC + ".stash"
-const defaultMaxTxnsToProcess = 1*1000*100
+const defaultMaxTxnsToProcess = 1 * 1000 * 100
 
 // TODO (jam): 2017-07-07 Change the stages to take a settings parameter
 // and move this into a local variable instead of a global variable.
@@ -68,6 +68,7 @@ var allStages = []stage{
 				txns:         txns,
 				longTxnSize:  1000,
 				txnBatchSize: txnBatchSize,
+				txnsStash:    db.C(txnsStashC),
 			}
 			return trimmer.Trim(collections)
 		},
@@ -83,8 +84,8 @@ var allStages = []stage{
 		func(db *mgo.Database, txns *mgo.Collection) error {
 			for {
 				stats, err := jujutxn.CleanAndPrune(jujutxn.CleanAndPruneArgs{
-					Txns:    txns,
-					MaxTime: time.Now().Add(-time.Hour),
+					Txns:                     txns,
+					MaxTime:                  time.Now().Add(-time.Hour),
 					MaxTransactionsToProcess: maxTxnsToProcess,
 				})
 				logger.Infof("clean and prune cleaned %d docs in %d collections\n"+

--- a/src/mgopurge/trim_test.go
+++ b/src/mgopurge/trim_test.go
@@ -256,10 +256,6 @@ func (s *TrimSuite) TestTrimMultiDocWithStash(c *gc.C) {
 	c.Check(result["foo"], gc.Equals, "bar")
 	c.Check(result["txn-queue"], gc.HasLen, 51)
 	err = stash.FindId(bson.D{{"c", s.coll.Name}, {"id", 1}}).One(&result)
-	// if err != nil {
-	//     c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotFound)
-	//     err = stash.FindId(bson.D{{"id": 1}, {"c", s.coll.Name}}).One(&result)
-	// }
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result["txn-queue"], gc.HasLen, 50)
 	trimmer := &LongTxnTrimmer{

--- a/src/mgopurge/trim_test.go
+++ b/src/mgopurge/trim_test.go
@@ -42,7 +42,7 @@ func (s *TrimSuite) TestTrimSimpleTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result["foo"], gc.Equals, "bar")
 	c.Check(result["txn-queue"], gc.HasLen, 1)
-	err = TrimLongTransactionQueues(s.txns, 100, "coll")
+	err = TrimLongTransactionQueues(s.txns, 100, "txns.stash", "coll")
 	c.Assert(err, jc.ErrorIsNil)
 	// untouched
 	err = s.coll.FindId(0).One(&result)
@@ -80,7 +80,7 @@ func (s *TrimSuite) createDocWith51Txns(c *gc.C) {
 
 func (s *TrimSuite) TestTrimNotLongEnough(c *gc.C) {
 	s.createDocWith51Txns(c)
-	err := TrimLongTransactionQueues(s.txns, 100, "coll")
+	err := TrimLongTransactionQueues(s.txns, 100, "txns.stash", "coll")
 	c.Assert(err, jc.ErrorIsNil)
 	// untouched
 	var result bson.M
@@ -222,4 +222,66 @@ func (s *TrimSuite) TestTrimMultiDocWithExtras(c *gc.C) {
 	count, err = s.txns.Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(count, gc.Equals, 3)
+}
+
+func (s *TrimSuite) TestTrimMultiDocWithStash(c *gc.C) {
+	stash := s.db.C("txns.stash")
+	err := s.runner.Run([]txn.Op{{
+		C:      s.coll.Name,
+		Id:     0,
+		Insert: bson.M{"foo": "bar"},
+	}}, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	// queue up a bunch of txns
+	txn.SetChaos(txn.Chaos{
+		KillChance: 1,
+		Breakpoint: "set-applying",
+	})
+	defer txn.SetChaos(txn.Chaos{})
+	ops := []txn.Op{{
+		C:      s.coll.Name,
+		Id:     0,
+		Update: bson.M{"$set": bson.M{"foo": "baz"}},
+	}, {
+		C:      s.coll.Name,
+		Id:     1,
+		Insert: bson.M{"new": "stuff"},
+	}}
+	for i := 0; i < 50; i++ {
+		c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
+	}
+	var result bson.M
+	err = s.coll.FindId(0).One(&result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result["foo"], gc.Equals, "bar")
+	c.Check(result["txn-queue"], gc.HasLen, 51)
+	err = stash.FindId(bson.D{{"c", s.coll.Name}, {"id", 1}}).One(&result)
+	// if err != nil {
+	//     c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotFound)
+	//     err = stash.FindId(bson.D{{"id": 1}, {"c", s.coll.Name}}).One(&result)
+	// }
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result["txn-queue"], gc.HasLen, 50)
+	trimmer := &LongTxnTrimmer{
+		txns:         s.txns,
+		longTxnSize:  50,
+		txnBatchSize: 13,
+		txnsStash:    stash,
+	}
+	count, err := s.txns.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 51)
+	err = trimmer.Trim([]string{s.coll.Name})
+	c.Assert(err, jc.ErrorIsNil)
+	// All of the Prepared but not completed txns should be removed
+	err = s.coll.FindId(0).One(&result)
+	c.Check(result["foo"], gc.Equals, "bar")
+	c.Check(result["txn-queue"], gc.HasLen, 1)
+	err = stash.Find(bson.M{"_id.id": 1}).One(&result)
+	// All txns that affected this doc have been removed
+	c.Check(result["txn-queue"], gc.HasLen, 0)
+	c.Check(trimmer.docCleanupCount, gc.Equals, 2)
+	count, err = s.txns.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 1)
 }


### PR DESCRIPTION
It turned out that you can get too-long txn-queues on a transaction that
might be inserting a document, which meant the referenced document was
still in the stash, not in the actual table it was supposed to end up
in.
And that meant we couldn't confirm that all docs were involved in the
long txn-queue so we didn't know if it was safe to purge the queue.

This update changes it so we check in txns.stash and give it special
handling since the docs there are keyed differently.

(I also ran go fmt with go 1.10, so some of the changes are just formatting)