### PR TITLE
Fix issue #30, use the right default txns.

### DIFF
--- a/src/mgopurge/main.go
+++ b/src/mgopurge/main.go
@@ -22,7 +22,7 @@ import (
 
 const txnsC = "txns"
 const txnsStashC = txnsC + ".stash"
-const defaultMaxTxnsToProcess = 1 * 1000 * 100
+const defaultMaxTxnsToProcess = 1 * 1000 * 1000
 
 // TODO (jam): 2017-07-07 Change the stages to take a settings parameter
 // and move this into a local variable instead of a global variable.


### PR DESCRIPTION
You can always specify a value to override the default, but we intended
1M txns / batch as the default, not 100,000.