### PR TITLE
Mgopurge snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 bin/
 pkg/
 src/mgopurge/version.go
+/build/
+/parts/
+/prime/
+/stage/
+.snapcraft/
+*.snap

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ build: generate
 release: clean check-clean generate
 	gb build -f
 
+snap-release: clean generate
+	gb build -f
+	cp bin/mgopurge ${SNAPCRAFT_PART_INSTALL}
+
 clean:
 	rm -rf bin/* pkg/* src/mgopurge/version.go
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,24 +6,22 @@ description: |
         * transaction ids referenced by documents but the transaction itself is missing.
         * transaction queues growing too long
         * being able to cleanup transactions that have been applied from the txns collection.
+# license is not currently supported in 'snapcraft stable'
+#license: AGPL v3
+type: app
 
 
 grade: devel
-confinement: devmode
+confinement: strict
 
 apps:
     mgopurge:
         command: mgopurge
+        plugs:
+            - network
 
 parts:
-    gb:
-        plugin: go
-        source: https://github.com/constabulary/gb.git
-        go-importpath: github.com/constabulary/gb
-        go-packages:
-            - github.com/constabulary/gb
     mgopurge:
-        after: [gb]
         source: .
         plugin: make
         artifacts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,19 +9,24 @@ description: |
 
 
 grade: devel
-confinement: classic
+confinement: devmode
 
 apps:
     mgopurge:
-        command: bin/mgopurge
+        command: mgopurge
 
 parts:
-    mgopurge:
-        source: .
+    gb:
         plugin: go
-        go-importpath: github.com/juju/mgopurge
-        override-build:
-            rm -rf bin/* pkg/* src/mgopurge/version.go
-            gb generate
-            gb build -f
-
+        source: https://github.com/constabulary/gb.git
+        go-importpath: github.com/constabulary/gb
+        go-packages:
+            - github.com/constabulary/gb
+    mgopurge:
+        after: [gb]
+        source: .
+        plugin: make
+        artifacts:
+            - bin/mgopurge
+        override-build: |
+            make snap-release

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,5 +21,7 @@ parts:
         plugin: go
         go-importpath: github.com/juju/mgopurge
         override-build:
-            make release
+            rm -rf bin/* pkg/* src/mgopurge/version.go
+            gb generate
+            gb build -f
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: mgopurge
+version: git
+summary: Cleanup Mongo databases managed by mgo/txn
+description: |
+    This runs several steps to handle known issues with mgo/txn. Specifically things like:
+        * transaction ids referenced by documents but the transaction itself is missing.
+        * transaction queues growing too long
+        * being able to cleanup transactions that have been applied from the txns collection.
+
+
+grade: devel
+confinement: classic
+
+apps:
+    mgopurge:
+        command: bin/mgopurge
+
+parts:
+    mgopurge:
+        source: .
+        plugin: go
+        go-importpath: github.com/juju/mgopurge
+        override-build:
+            make release
+


### PR DESCRIPTION
This adds a snap/snapcraft.yaml definition and a bit of a Makefile tweak to be able to build a snap of mgopurge.

I don't think this is perfect, as I'd rather do something like use the "go" plugin, or the "godeps", etc. But because mgopurge is built with 'gb' to manage dependencies, etc, I wanted to start with something that works.

On the plus side, mgopurge can be fairly easily put into strict mode as long as it has network access. It doesn't have any particularly difficult system integration issues.

