### PR TITLE
1.9 txn in queue

### DIFF
--- a/invalidtxnrefs.go
+++ b/invalidtxnrefs.go
@@ -1,0 +1,25 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"github.com/juju/mgo/v2"
+)
+// InvalidTxnReferenceCleaner looks for transactions that reference documents that cannot be found,
+// as well as documents that do not have the transaction in their queue.
+// These cannot be resumed cleanly, so we just remove them.
+type InvalidTxnReferenceCleaner struct {
+	txns *mgo.Collection
+	db *mgo.Database
+
+	// acceptablyMissingCollections lists the collection names that we 'accept' if they are
+	// missing. Normally the only collection that things should 'disappear' is "metrics".
+	// Because they are deleted by a batch process. However,
+	//we make this field serviceable by allowing additional collections to be supplied.
+	acceptablyMissingCollections []string
+}
+
+func CleanupInvalidTxnReferences(txns *mgo.Collection) error {
+
+}

--- a/invalidtxnrefs.go
+++ b/invalidtxnrefs.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"github.com/juju/mgo/v2"
+	"github.com/juju/mgo/v2/bson"
 )
 // InvalidTxnReferenceCleaner looks for transactions that reference documents that cannot be found,
 // as well as documents that do not have the transaction in their queue.
@@ -20,6 +21,40 @@ type InvalidTxnReferenceCleaner struct {
 	acceptablyMissingCollections []string
 }
 
+
+func (invalidtxn *InvalidTxnReferenceCleaner) lookupDoc(coll string, id interface{}) (*txnDoc, error) {
+	var doc txnDoc
+	collection := invalidtxn.db.C(coll)
+	err := collection.FindId(id).One(&doc)
+	if err != nil {
+		return nil, err
+	}
+}
+func (invalidtxn *InvalidTxnReferenceCleaner) Run() {
+	iter := invalidtxn.iterStagedTransactions()
+	var txn rawTransaction
+	for iter.Next(&txn) {
+		for _, op := range txn.Ops {
+			// TODO: eventually we could try to do this in some sort of batch lookup,
+			//  but for now that is premature optimization
+			doc, err := invalidtxn.lookupDoc(op.C, op.Id)
+		}
+	}
+}
+
+func (invalidtxn *InvalidTxnReferenceCleaner) iterStagedTransactions() *mgo.Iter{
+	// Look for transactions that are in either stage 1 "Pending" or stage 2 "Prepared"
+	query := invalidtxn.txns.Find(
+		bson.M{"s": bson.M{"$in": []int{1, 2}}},
+	).Select(txnFields)
+	return query.Iter()
+}
+
 func CleanupInvalidTxnReferences(txns *mgo.Collection) error {
 
+	cleaner := InvalidTxnReferenceCleaner{
+		txns: txns,
+		db: txns.Database,
+		acceptablyMissingCollections: []string{},
+	}
 }

--- a/invalidtxnrefs.go
+++ b/invalidtxnrefs.go
@@ -18,7 +18,7 @@ type InvalidTxnReferenceCleaner struct {
 	// acceptablyMissingCollections lists the collection names that we 'accept' if they are
 	// missing. Normally the only collection that things should 'disappear' is "metrics".
 	// Because they are deleted by a batch process. However,
-	//we make this field serviceable by allowing additional collections to be supplied.
+	// we make this field serviceable by allowing additional collections to be supplied.
 	acceptablyMissingCollections []string
 }
 

--- a/invalidtxnrefs.go
+++ b/invalidtxnrefs.go
@@ -88,11 +88,11 @@ func (invalidtxn *InvalidTxnReferenceCleaner) iterStagedTransactions() *mgo.Iter
 	return query.Iter()
 }
 
-func CleanupInvalidTxnReferences(txns *mgo.Collection) error {
+func CleanupInvalidTxnReferences(db *mgo.Database, txns *mgo.Collection) error {
 
 	cleaner := InvalidTxnReferenceCleaner{
 		txns: txns,
-		db: txns.Database,
+		db: db,
 		acceptablyMissingCollections: []string{},
 	}
 	return cleaner.Run()

--- a/invalidtxnrefs_test.go
+++ b/invalidtxnrefs_test.go
@@ -1,0 +1,277 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package main
+
+import (
+	"github.com/juju/mgo/v2"
+	"github.com/juju/mgo/v2/bson"
+	"github.com/juju/mgo/v2/txn"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type InvalidTxnReferenceCleanerSuite struct {
+	testing.IsolatedMgoSuite
+
+	runner *txn.Runner
+	db     *mgo.Database
+	coll   *mgo.Collection
+	txns   *mgo.Collection
+}
+
+var _ = gc.Suite(&InvalidTxnReferenceCleanerSuite{})
+
+func (s *InvalidTxnReferenceCleanerSuite) SetUpTest(c *gc.C) {
+	s.IsolatedMgoSuite.SetUpTest(c)
+	s.db = s.Session.DB("test")
+	s.txns = s.db.C("txns")
+	s.coll = s.db.C("coll")
+	s.runner = txn.NewRunner(s.txns)
+}
+
+func (s *InvalidTxnReferenceCleanerSuite) TestMissingDocSimple(c *gc.C) {
+	err := s.runner.Run([]txn.Op{{
+		C:      "coll",
+		Id:     0,
+		Insert: bson.M{"foo": "bar"},
+	}}, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	var result bson.M
+	err = s.coll.FindId(0).One(&result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result["foo"], gc.Equals, "bar")
+	c.Check(result["txn-queue"], gc.HasLen, 1)
+}
+
+func (s *InvalidTxnReferenceCleanerSuite) createDocWith51Txns(c *gc.C) {
+	err := s.runner.Run([]txn.Op{{
+		C:      s.coll.Name,
+		Id:     0,
+		Insert: bson.M{"foo": "bar"},
+	}}, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	// queue up a bunch of txns
+	txn.SetChaos(txn.Chaos{
+		KillChance: 1,
+		Breakpoint: "set-applying",
+	})
+	defer txn.SetChaos(txn.Chaos{})
+	ops := []txn.Op{{
+		C:      s.coll.Name,
+		Id:     0,
+		Update: bson.M{"$set": bson.M{"foo": "baz"}},
+	}}
+	for i := 0; i < 50; i++ {
+		c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
+	}
+	var result bson.M
+	err = s.coll.FindId(0).One(&result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result["foo"], gc.Equals, "bar")
+	c.Check(result["txn-queue"], gc.HasLen, 51)
+}
+
+func (s *InvalidTxnReferenceCleanerSuite) TestTrimNotLongEnough(c *gc.C) {
+	s.createDocWith51Txns(c)
+	err := TrimLongTransactionQueues(s.txns, 100, "txns.stash", "coll")
+	c.Assert(err, jc.ErrorIsNil)
+	// untouched
+	var result bson.M
+	err = s.coll.FindId(0).One(&result)
+	c.Check(result["foo"], gc.Equals, "bar")
+	c.Check(result["txn-queue"], gc.HasLen, 51)
+}
+
+func (s *InvalidTxnReferenceCleanerSuite) TestTrimmedSingleDoc(c *gc.C) {
+	s.createDocWith51Txns(c)
+	trimmer := &LongTxnTrimmer{
+		txns:         s.txns,
+		longTxnSize:  50,
+		txnBatchSize: 5,
+	}
+	count, err := s.txns.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 51)
+	err = trimmer.Trim([]string{s.coll.Name})
+	c.Assert(err, jc.ErrorIsNil)
+	// All of the Prepared but not completed txns should be removed
+	var result bson.M
+	err = s.coll.FindId(0).One(&result)
+	c.Check(result["foo"], gc.Equals, "bar")
+	c.Check(result["txn-queue"], gc.HasLen, 1)
+	c.Check(trimmer.docCleanupCount, gc.Equals, 1)
+	count, err = s.txns.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 1)
+}
+
+func (s *InvalidTxnReferenceCleanerSuite) createMultiDocTxns(c *gc.C) {
+	err := s.runner.Run([]txn.Op{{
+		C:      s.coll.Name,
+		Id:     0,
+		Insert: bson.M{"foo": "bar"},
+	}}, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.runner.Run([]txn.Op{{
+		C:      s.coll.Name,
+		Id:     1,
+		Insert: bson.M{"foo": "boing"},
+	}}, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	// queue up a bunch of txns
+	txn.SetChaos(txn.Chaos{
+		KillChance: 1,
+		Breakpoint: "set-applying",
+	})
+	defer txn.SetChaos(txn.Chaos{})
+	ops := []txn.Op{{
+		C:      s.coll.Name,
+		Id:     0,
+		Update: bson.M{"$set": bson.M{"foo": "baz"}},
+	}, {
+		C:      s.coll.Name,
+		Id:     1,
+		Update: bson.M{"$set": bson.M{"foo": "bling"}},
+	}}
+	for i := 0; i < 50; i++ {
+		c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
+	}
+	var result bson.M
+	err = s.coll.FindId(0).One(&result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result["foo"], gc.Equals, "bar")
+	c.Check(result["txn-queue"], gc.HasLen, 51)
+	err = s.coll.FindId(1).One(&result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result["foo"], gc.Equals, "boing")
+	c.Check(result["txn-queue"], gc.HasLen, 51)
+}
+
+func (s *InvalidTxnReferenceCleanerSuite) TestTrimMultiDoc(c *gc.C) {
+	s.createMultiDocTxns(c)
+	trimmer := &LongTxnTrimmer{
+		txns:         s.txns,
+		longTxnSize:  50,
+		txnBatchSize: 13,
+	}
+	count, err := s.txns.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 52)
+	err = trimmer.Trim([]string{s.coll.Name})
+	c.Assert(err, jc.ErrorIsNil)
+	// All of the Prepared but not completed txns should be removed
+	var result bson.M
+	err = s.coll.FindId(0).One(&result)
+	c.Check(result["foo"], gc.Equals, "bar")
+	c.Check(result["txn-queue"], gc.HasLen, 1)
+	err = s.coll.FindId(1).One(&result)
+	c.Check(result["foo"], gc.Equals, "boing")
+	c.Check(result["txn-queue"], gc.HasLen, 1)
+	c.Check(trimmer.docCleanupCount, gc.Equals, 2)
+	count, err = s.txns.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 2)
+}
+
+func (s *InvalidTxnReferenceCleanerSuite) TestTrimMultiDocWithExtras(c *gc.C) {
+	s.createMultiDocTxns(c)
+	// Now we also include another document that intersect with
+	// those documents whose queues are way too long.
+	// These transactions should not be removed
+	txn.SetChaos(txn.Chaos{
+		KillChance: 1,
+		Breakpoint: "set-applying",
+	})
+	defer txn.SetChaos(txn.Chaos{})
+	err := s.runner.Run([]txn.Op{{
+		C:      s.coll.Name,
+		Id:     0,
+		Update: bson.M{"$set": bson.M{"baz": "bling"}},
+	}, {
+		C:      s.coll.Name,
+		Id:     4,
+		Insert: bson.M{"new": "stuff"},
+	}}, "", nil)
+	c.Assert(err, gc.Equals, txn.ErrChaos)
+	trimmer := &LongTxnTrimmer{
+		txns:         s.txns,
+		longTxnSize:  50,
+		txnBatchSize: 17,
+	}
+	count, err := s.txns.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 53)
+	err = trimmer.Trim([]string{s.coll.Name})
+	c.Assert(err, jc.ErrorIsNil)
+	// All of the Prepared but not completed txns should be removed
+	var result bson.M
+	err = s.coll.FindId(0).One(&result)
+	c.Check(result["foo"], gc.Equals, "bar")
+	c.Check(result["txn-queue"], gc.HasLen, 2)
+	err = s.coll.FindId(1).One(&result)
+	c.Check(result["foo"], gc.Equals, "boing")
+	c.Check(result["txn-queue"], gc.HasLen, 1)
+	c.Check(trimmer.docCleanupCount, gc.Equals, 2)
+	count, err = s.txns.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 3)
+}
+
+func (s *InvalidTxnReferenceCleanerSuite) TestTrimMultiDocWithStash(c *gc.C) {
+	stash := s.db.C("txns.stash")
+	err := s.runner.Run([]txn.Op{{
+		C:      s.coll.Name,
+		Id:     0,
+		Insert: bson.M{"foo": "bar"},
+	}}, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	// queue up a bunch of txns
+	txn.SetChaos(txn.Chaos{
+		KillChance: 1,
+		Breakpoint: "set-applying",
+	})
+	defer txn.SetChaos(txn.Chaos{})
+	ops := []txn.Op{{
+		C:      s.coll.Name,
+		Id:     0,
+		Update: bson.M{"$set": bson.M{"foo": "baz"}},
+	}, {
+		C:      s.coll.Name,
+		Id:     1,
+		Insert: bson.M{"new": "stuff"},
+	}}
+	for i := 0; i < 50; i++ {
+		c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
+	}
+	var result bson.M
+	err = s.coll.FindId(0).One(&result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result["foo"], gc.Equals, "bar")
+	c.Check(result["txn-queue"], gc.HasLen, 51)
+	err = stash.FindId(bson.D{{"c", s.coll.Name}, {"id", 1}}).One(&result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result["txn-queue"], gc.HasLen, 50)
+	trimmer := &LongTxnTrimmer{
+		txns:         s.txns,
+		longTxnSize:  50,
+		txnBatchSize: 13,
+		txnsStash:    stash,
+	}
+	count, err := s.txns.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 51)
+	err = trimmer.Trim([]string{s.coll.Name})
+	c.Assert(err, jc.ErrorIsNil)
+	// All of the Prepared but not completed txns should be removed
+	err = s.coll.FindId(0).One(&result)
+	c.Check(result["foo"], gc.Equals, "bar")
+	c.Check(result["txn-queue"], gc.HasLen, 1)
+	err = stash.Find(bson.M{"_id.id": 1}).One(&result)
+	// All txns that affected this doc have been removed
+	c.Check(result["txn-queue"], gc.HasLen, 0)
+	c.Check(trimmer.docCleanupCount, gc.Equals, 2)
+	count, err = s.txns.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 1)
+}

--- a/invalidtxnrefs_test.go
+++ b/invalidtxnrefs_test.go
@@ -48,6 +48,9 @@ func (s *InvalidTxnReferenceCleanerSuite) TestNoMissingDoc(c *gc.C) {
 	c.Check(result["txn-queue"], gc.HasLen, 1)
 }
 
+func tokenToObjectId(token string) bson.ObjectId {
+	return bson.ObjectIdHex(token[:24])
+}
 func (s *InvalidTxnReferenceCleanerSuite) TestTxnWithNoDoc(c *gc.C) {
 	err := s.runner.Run([]txn.Op{{
 		C:      "coll",
@@ -63,278 +66,29 @@ func (s *InvalidTxnReferenceCleanerSuite) TestTxnWithNoDoc(c *gc.C) {
 	ops := []txn.Op{{
 		C:      s.coll.Name,
 		Id:     0,
+		Assert: bson.M{"foo": "bar"}, // assert that the document still says "bar"
 		Update: bson.M{"$set": bson.M{"foo": "baz"}},
 	}}
-	c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
+	oid := bson.NewObjectId()
+	c.Assert(s.runner.Run(ops, oid, nil), gc.Equals, txn.ErrChaos)
 	var result bson.M
 	err = s.coll.FindId(0).One(&result)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result["foo"], gc.Equals, "bar")
-	c.Check(result["txn-queue"], gc.HasLen, 2)
+	queue := result["txn-queue"].([]interface{})
+	c.Check(queue, gc.HasLen, 2)
+	token := queue[1].(string)
+	c.Check(tokenToObjectId(token), gc.Equals, oid)
 	s.coll.RemoveId(0)
+	var raw rawTransaction
+	c.Assert(s.txns.FindId(oid).One(&raw), jc.ErrorIsNil)
+	c.Check(raw.State, gc.Equals, 2) // prepared
 	err = CleanupInvalidTxnReferences(s.txns)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.txns.FindId(oid).One(&raw), jc.ErrorIsNil)
+	c.Check(raw.State, gc.Equals, 1) // preparing
 	c.Assert(s.runner.ResumeAll(), jc.ErrorIsNil)
+	c.Assert(s.txns.FindId(oid).One(&raw), jc.ErrorIsNil)
+	c.Check(raw.State, gc.Equals, 5) // cancelled
+	c.Assert(s.coll.FindId(0).One(&result), gc.Equals, mgo.ErrNotFound)
 }
-
-func (s *InvalidTxnReferenceCleanerSuite) TestTxnQueueMissingTxn(c *gc.C) {
-	err := s.runner.Run([]txn.Op{{
-		C:      "coll",
-		Id:     0,
-		Insert: bson.M{"foo": "bar"},
-	}}, "", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	txn.SetChaos(txn.Chaos{
-		KillChance: 1,
-		Breakpoint: "set-applying",
-	})
-	defer txn.SetChaos(txn.Chaos{})
-	ops := []txn.Op{{
-		C:      s.coll.Name,
-		Id:     0,
-		Update: bson.M{"$set": bson.M{"foo": "baz"}},
-	}}
-	c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
-	var result bson.M
-	err = s.coll.FindId(0).One(&result)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(result["foo"], gc.Equals, "bar")
-	c.Check(result["txn-queue"], gc.HasLen, 2)
-	s.coll.RemoveId(0)
-	err = CleanupInvalidTxnReferences(s.txns)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.runner.ResumeAll(), jc.ErrorIsNil)
-}
-
-// func (s *InvalidTxnReferenceCleanerSuite) createDocWith51Txns(c *gc.C) {
-// 	err := s.runner.Run([]txn.Op{{
-// 		C:      s.coll.Name,
-// 		Id:     0,
-// 		Insert: bson.M{"foo": "bar"},
-// 	}}, "", nil)
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	// queue up a bunch of txns
-// 	txn.SetChaos(txn.Chaos{
-// 		KillChance: 1,
-// 		Breakpoint: "set-applying",
-// 	})
-// 	defer txn.SetChaos(txn.Chaos{})
-// 	ops := []txn.Op{{
-// 		C:      s.coll.Name,
-// 		Id:     0,
-// 		Update: bson.M{"$set": bson.M{"foo": "baz"}},
-// 	}}
-// 	for i := 0; i < 50; i++ {
-// 		c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
-// 	}
-// 	var result bson.M
-// 	err = s.coll.FindId(0).One(&result)
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Check(result["foo"], gc.Equals, "bar")
-// 	c.Check(result["txn-queue"], gc.HasLen, 51)
-// }
-// 
-// func (s *InvalidTxnReferenceCleanerSuite) TestTrimNotLongEnough(c *gc.C) {
-// 	s.createDocWith51Txns(c)
-// 	err := TrimLongTransactionQueues(s.txns, 100, "txns.stash", "coll")
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	// untouched
-// 	var result bson.M
-// 	err = s.coll.FindId(0).One(&result)
-// 	c.Check(result["foo"], gc.Equals, "bar")
-// 	c.Check(result["txn-queue"], gc.HasLen, 51)
-// }
-// 
-// func (s *InvalidTxnReferenceCleanerSuite) TestTrimmedSingleDoc(c *gc.C) {
-// 	s.createDocWith51Txns(c)
-// 	trimmer := &LongTxnTrimmer{
-// 		txns:         s.txns,
-// 		longTxnSize:  50,
-// 		txnBatchSize: 5,
-// 	}
-// 	count, err := s.txns.Count()
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Check(count, gc.Equals, 51)
-// 	err = trimmer.Trim([]string{s.coll.Name})
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	// All of the Prepared but not completed txns should be removed
-// 	var result bson.M
-// 	err = s.coll.FindId(0).One(&result)
-// 	c.Check(result["foo"], gc.Equals, "bar")
-// 	c.Check(result["txn-queue"], gc.HasLen, 1)
-// 	c.Check(trimmer.docCleanupCount, gc.Equals, 1)
-// 	count, err = s.txns.Count()
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Check(count, gc.Equals, 1)
-// }
-// 
-// func (s *InvalidTxnReferenceCleanerSuite) createMultiDocTxns(c *gc.C) {
-// 	err := s.runner.Run([]txn.Op{{
-// 		C:      s.coll.Name,
-// 		Id:     0,
-// 		Insert: bson.M{"foo": "bar"},
-// 	}}, "", nil)
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	err = s.runner.Run([]txn.Op{{
-// 		C:      s.coll.Name,
-// 		Id:     1,
-// 		Insert: bson.M{"foo": "boing"},
-// 	}}, "", nil)
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	// queue up a bunch of txns
-// 	txn.SetChaos(txn.Chaos{
-// 		KillChance: 1,
-// 		Breakpoint: "set-applying",
-// 	})
-// 	defer txn.SetChaos(txn.Chaos{})
-// 	ops := []txn.Op{{
-// 		C:      s.coll.Name,
-// 		Id:     0,
-// 		Update: bson.M{"$set": bson.M{"foo": "baz"}},
-// 	}, {
-// 		C:      s.coll.Name,
-// 		Id:     1,
-// 		Update: bson.M{"$set": bson.M{"foo": "bling"}},
-// 	}}
-// 	for i := 0; i < 50; i++ {
-// 		c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
-// 	}
-// 	var result bson.M
-// 	err = s.coll.FindId(0).One(&result)
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Check(result["foo"], gc.Equals, "bar")
-// 	c.Check(result["txn-queue"], gc.HasLen, 51)
-// 	err = s.coll.FindId(1).One(&result)
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Check(result["foo"], gc.Equals, "boing")
-// 	c.Check(result["txn-queue"], gc.HasLen, 51)
-// }
-// 
-// func (s *InvalidTxnReferenceCleanerSuite) TestTrimMultiDoc(c *gc.C) {
-// 	s.createMultiDocTxns(c)
-// 	trimmer := &LongTxnTrimmer{
-// 		txns:         s.txns,
-// 		longTxnSize:  50,
-// 		txnBatchSize: 13,
-// 	}
-// 	count, err := s.txns.Count()
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Check(count, gc.Equals, 52)
-// 	err = trimmer.Trim([]string{s.coll.Name})
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	// All of the Prepared but not completed txns should be removed
-// 	var result bson.M
-// 	err = s.coll.FindId(0).One(&result)
-// 	c.Check(result["foo"], gc.Equals, "bar")
-// 	c.Check(result["txn-queue"], gc.HasLen, 1)
-// 	err = s.coll.FindId(1).One(&result)
-// 	c.Check(result["foo"], gc.Equals, "boing")
-// 	c.Check(result["txn-queue"], gc.HasLen, 1)
-// 	c.Check(trimmer.docCleanupCount, gc.Equals, 2)
-// 	count, err = s.txns.Count()
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Check(count, gc.Equals, 2)
-// }
-// 
-// func (s *InvalidTxnReferenceCleanerSuite) TestTrimMultiDocWithExtras(c *gc.C) {
-// 	s.createMultiDocTxns(c)
-// 	// Now we also include another document that intersect with
-// 	// those documents whose queues are way too long.
-// 	// These transactions should not be removed
-// 	txn.SetChaos(txn.Chaos{
-// 		KillChance: 1,
-// 		Breakpoint: "set-applying",
-// 	})
-// 	defer txn.SetChaos(txn.Chaos{})
-// 	err := s.runner.Run([]txn.Op{{
-// 		C:      s.coll.Name,
-// 		Id:     0,
-// 		Update: bson.M{"$set": bson.M{"baz": "bling"}},
-// 	}, {
-// 		C:      s.coll.Name,
-// 		Id:     4,
-// 		Insert: bson.M{"new": "stuff"},
-// 	}}, "", nil)
-// 	c.Assert(err, gc.Equals, txn.ErrChaos)
-// 	trimmer := &LongTxnTrimmer{
-// 		txns:         s.txns,
-// 		longTxnSize:  50,
-// 		txnBatchSize: 17,
-// 	}
-// 	count, err := s.txns.Count()
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Check(count, gc.Equals, 53)
-// 	err = trimmer.Trim([]string{s.coll.Name})
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	// All of the Prepared but not completed txns should be removed
-// 	var result bson.M
-// 	err = s.coll.FindId(0).One(&result)
-// 	c.Check(result["foo"], gc.Equals, "bar")
-// 	c.Check(result["txn-queue"], gc.HasLen, 2)
-// 	err = s.coll.FindId(1).One(&result)
-// 	c.Check(result["foo"], gc.Equals, "boing")
-// 	c.Check(result["txn-queue"], gc.HasLen, 1)
-// 	c.Check(trimmer.docCleanupCount, gc.Equals, 2)
-// 	count, err = s.txns.Count()
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Check(count, gc.Equals, 3)
-// }
-// 
-// func (s *InvalidTxnReferenceCleanerSuite) TestTrimMultiDocWithStash(c *gc.C) {
-// 	stash := s.db.C("txns.stash")
-// 	err := s.runner.Run([]txn.Op{{
-// 		C:      s.coll.Name,
-// 		Id:     0,
-// 		Insert: bson.M{"foo": "bar"},
-// 	}}, "", nil)
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	// queue up a bunch of txns
-// 	txn.SetChaos(txn.Chaos{
-// 		KillChance: 1,
-// 		Breakpoint: "set-applying",
-// 	})
-// 	defer txn.SetChaos(txn.Chaos{})
-// 	ops := []txn.Op{{
-// 		C:      s.coll.Name,
-// 		Id:     0,
-// 		Update: bson.M{"$set": bson.M{"foo": "baz"}},
-// 	}, {
-// 		C:      s.coll.Name,
-// 		Id:     1,
-// 		Insert: bson.M{"new": "stuff"},
-// 	}}
-// 	for i := 0; i < 50; i++ {
-// 		c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
-// 	}
-// 	var result bson.M
-// 	err = s.coll.FindId(0).One(&result)
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Check(result["foo"], gc.Equals, "bar")
-// 	c.Check(result["txn-queue"], gc.HasLen, 51)
-// 	err = stash.FindId(bson.D{{"c", s.coll.Name}, {"id", 1}}).One(&result)
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Check(result["txn-queue"], gc.HasLen, 50)
-// 	trimmer := &LongTxnTrimmer{
-// 		txns:         s.txns,
-// 		longTxnSize:  50,
-// 		txnBatchSize: 13,
-// 		txnsStash:    stash,
-// 	}
-// 	count, err := s.txns.Count()
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Check(count, gc.Equals, 51)
-// 	err = trimmer.Trim([]string{s.coll.Name})
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	// All of the Prepared but not completed txns should be removed
-// 	err = s.coll.FindId(0).One(&result)
-// 	c.Check(result["foo"], gc.Equals, "bar")
-// 	c.Check(result["txn-queue"], gc.HasLen, 1)
-// 	err = stash.Find(bson.M{"_id.id": 1}).One(&result)
-// 	// All txns that affected this doc have been removed
-// 	c.Check(result["txn-queue"], gc.HasLen, 0)
-// 	c.Check(trimmer.docCleanupCount, gc.Equals, 2)
-// 	count, err = s.txns.Count()
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Check(count, gc.Equals, 1)
-// }
-// 

--- a/invalidtxnrefs_test.go
+++ b/invalidtxnrefs_test.go
@@ -30,7 +30,7 @@ func (s *InvalidTxnReferenceCleanerSuite) SetUpTest(c *gc.C) {
 	s.runner = txn.NewRunner(s.txns)
 }
 
-func (s *InvalidTxnReferenceCleanerSuite) TestMissingDocSimple(c *gc.C) {
+func (s *InvalidTxnReferenceCleanerSuite) TestNoMissingDoc(c *gc.C) {
 	err := s.runner.Run([]txn.Op{{
 		C:      "coll",
 		Id:     0,
@@ -42,236 +42,241 @@ func (s *InvalidTxnReferenceCleanerSuite) TestMissingDocSimple(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result["foo"], gc.Equals, "bar")
 	c.Check(result["txn-queue"], gc.HasLen, 1)
-}
-
-func (s *InvalidTxnReferenceCleanerSuite) createDocWith51Txns(c *gc.C) {
-	err := s.runner.Run([]txn.Op{{
-		C:      s.coll.Name,
-		Id:     0,
-		Insert: bson.M{"foo": "bar"},
-	}}, "", nil)
+	err = CleanupInvalidTxnReferences(s.txns)
 	c.Assert(err, jc.ErrorIsNil)
-	// queue up a bunch of txns
-	txn.SetChaos(txn.Chaos{
-		KillChance: 1,
-		Breakpoint: "set-applying",
-	})
-	defer txn.SetChaos(txn.Chaos{})
-	ops := []txn.Op{{
-		C:      s.coll.Name,
-		Id:     0,
-		Update: bson.M{"$set": bson.M{"foo": "baz"}},
-	}}
-	for i := 0; i < 50; i++ {
-		c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
-	}
-	var result bson.M
-	err = s.coll.FindId(0).One(&result)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(result["foo"], gc.Equals, "bar")
-	c.Check(result["txn-queue"], gc.HasLen, 51)
-}
-
-func (s *InvalidTxnReferenceCleanerSuite) TestTrimNotLongEnough(c *gc.C) {
-	s.createDocWith51Txns(c)
-	err := TrimLongTransactionQueues(s.txns, 100, "txns.stash", "coll")
-	c.Assert(err, jc.ErrorIsNil)
-	// untouched
-	var result bson.M
-	err = s.coll.FindId(0).One(&result)
-	c.Check(result["foo"], gc.Equals, "bar")
-	c.Check(result["txn-queue"], gc.HasLen, 51)
-}
-
-func (s *InvalidTxnReferenceCleanerSuite) TestTrimmedSingleDoc(c *gc.C) {
-	s.createDocWith51Txns(c)
-	trimmer := &LongTxnTrimmer{
-		txns:         s.txns,
-		longTxnSize:  50,
-		txnBatchSize: 5,
-	}
-	count, err := s.txns.Count()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(count, gc.Equals, 51)
-	err = trimmer.Trim([]string{s.coll.Name})
-	c.Assert(err, jc.ErrorIsNil)
-	// All of the Prepared but not completed txns should be removed
-	var result bson.M
-	err = s.coll.FindId(0).One(&result)
 	c.Check(result["foo"], gc.Equals, "bar")
 	c.Check(result["txn-queue"], gc.HasLen, 1)
-	c.Check(trimmer.docCleanupCount, gc.Equals, 1)
-	count, err = s.txns.Count()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(count, gc.Equals, 1)
 }
 
-func (s *InvalidTxnReferenceCleanerSuite) createMultiDocTxns(c *gc.C) {
-	err := s.runner.Run([]txn.Op{{
-		C:      s.coll.Name,
-		Id:     0,
-		Insert: bson.M{"foo": "bar"},
-	}}, "", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.runner.Run([]txn.Op{{
-		C:      s.coll.Name,
-		Id:     1,
-		Insert: bson.M{"foo": "boing"},
-	}}, "", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	// queue up a bunch of txns
-	txn.SetChaos(txn.Chaos{
-		KillChance: 1,
-		Breakpoint: "set-applying",
-	})
-	defer txn.SetChaos(txn.Chaos{})
-	ops := []txn.Op{{
-		C:      s.coll.Name,
-		Id:     0,
-		Update: bson.M{"$set": bson.M{"foo": "baz"}},
-	}, {
-		C:      s.coll.Name,
-		Id:     1,
-		Update: bson.M{"$set": bson.M{"foo": "bling"}},
-	}}
-	for i := 0; i < 50; i++ {
-		c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
-	}
-	var result bson.M
-	err = s.coll.FindId(0).One(&result)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(result["foo"], gc.Equals, "bar")
-	c.Check(result["txn-queue"], gc.HasLen, 51)
-	err = s.coll.FindId(1).One(&result)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(result["foo"], gc.Equals, "boing")
-	c.Check(result["txn-queue"], gc.HasLen, 51)
-}
-
-func (s *InvalidTxnReferenceCleanerSuite) TestTrimMultiDoc(c *gc.C) {
-	s.createMultiDocTxns(c)
-	trimmer := &LongTxnTrimmer{
-		txns:         s.txns,
-		longTxnSize:  50,
-		txnBatchSize: 13,
-	}
-	count, err := s.txns.Count()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(count, gc.Equals, 52)
-	err = trimmer.Trim([]string{s.coll.Name})
-	c.Assert(err, jc.ErrorIsNil)
-	// All of the Prepared but not completed txns should be removed
-	var result bson.M
-	err = s.coll.FindId(0).One(&result)
-	c.Check(result["foo"], gc.Equals, "bar")
-	c.Check(result["txn-queue"], gc.HasLen, 1)
-	err = s.coll.FindId(1).One(&result)
-	c.Check(result["foo"], gc.Equals, "boing")
-	c.Check(result["txn-queue"], gc.HasLen, 1)
-	c.Check(trimmer.docCleanupCount, gc.Equals, 2)
-	count, err = s.txns.Count()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(count, gc.Equals, 2)
-}
-
-func (s *InvalidTxnReferenceCleanerSuite) TestTrimMultiDocWithExtras(c *gc.C) {
-	s.createMultiDocTxns(c)
-	// Now we also include another document that intersect with
-	// those documents whose queues are way too long.
-	// These transactions should not be removed
-	txn.SetChaos(txn.Chaos{
-		KillChance: 1,
-		Breakpoint: "set-applying",
-	})
-	defer txn.SetChaos(txn.Chaos{})
-	err := s.runner.Run([]txn.Op{{
-		C:      s.coll.Name,
-		Id:     0,
-		Update: bson.M{"$set": bson.M{"baz": "bling"}},
-	}, {
-		C:      s.coll.Name,
-		Id:     4,
-		Insert: bson.M{"new": "stuff"},
-	}}, "", nil)
-	c.Assert(err, gc.Equals, txn.ErrChaos)
-	trimmer := &LongTxnTrimmer{
-		txns:         s.txns,
-		longTxnSize:  50,
-		txnBatchSize: 17,
-	}
-	count, err := s.txns.Count()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(count, gc.Equals, 53)
-	err = trimmer.Trim([]string{s.coll.Name})
-	c.Assert(err, jc.ErrorIsNil)
-	// All of the Prepared but not completed txns should be removed
-	var result bson.M
-	err = s.coll.FindId(0).One(&result)
-	c.Check(result["foo"], gc.Equals, "bar")
-	c.Check(result["txn-queue"], gc.HasLen, 2)
-	err = s.coll.FindId(1).One(&result)
-	c.Check(result["foo"], gc.Equals, "boing")
-	c.Check(result["txn-queue"], gc.HasLen, 1)
-	c.Check(trimmer.docCleanupCount, gc.Equals, 2)
-	count, err = s.txns.Count()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(count, gc.Equals, 3)
-}
-
-func (s *InvalidTxnReferenceCleanerSuite) TestTrimMultiDocWithStash(c *gc.C) {
-	stash := s.db.C("txns.stash")
-	err := s.runner.Run([]txn.Op{{
-		C:      s.coll.Name,
-		Id:     0,
-		Insert: bson.M{"foo": "bar"},
-	}}, "", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	// queue up a bunch of txns
-	txn.SetChaos(txn.Chaos{
-		KillChance: 1,
-		Breakpoint: "set-applying",
-	})
-	defer txn.SetChaos(txn.Chaos{})
-	ops := []txn.Op{{
-		C:      s.coll.Name,
-		Id:     0,
-		Update: bson.M{"$set": bson.M{"foo": "baz"}},
-	}, {
-		C:      s.coll.Name,
-		Id:     1,
-		Insert: bson.M{"new": "stuff"},
-	}}
-	for i := 0; i < 50; i++ {
-		c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
-	}
-	var result bson.M
-	err = s.coll.FindId(0).One(&result)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(result["foo"], gc.Equals, "bar")
-	c.Check(result["txn-queue"], gc.HasLen, 51)
-	err = stash.FindId(bson.D{{"c", s.coll.Name}, {"id", 1}}).One(&result)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(result["txn-queue"], gc.HasLen, 50)
-	trimmer := &LongTxnTrimmer{
-		txns:         s.txns,
-		longTxnSize:  50,
-		txnBatchSize: 13,
-		txnsStash:    stash,
-	}
-	count, err := s.txns.Count()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(count, gc.Equals, 51)
-	err = trimmer.Trim([]string{s.coll.Name})
-	c.Assert(err, jc.ErrorIsNil)
-	// All of the Prepared but not completed txns should be removed
-	err = s.coll.FindId(0).One(&result)
-	c.Check(result["foo"], gc.Equals, "bar")
-	c.Check(result["txn-queue"], gc.HasLen, 1)
-	err = stash.Find(bson.M{"_id.id": 1}).One(&result)
-	// All txns that affected this doc have been removed
-	c.Check(result["txn-queue"], gc.HasLen, 0)
-	c.Check(trimmer.docCleanupCount, gc.Equals, 2)
-	count, err = s.txns.Count()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(count, gc.Equals, 1)
-}
+// func (s *InvalidTxnReferenceCleanerSuite) createDocWith51Txns(c *gc.C) {
+// 	err := s.runner.Run([]txn.Op{{
+// 		C:      s.coll.Name,
+// 		Id:     0,
+// 		Insert: bson.M{"foo": "bar"},
+// 	}}, "", nil)
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	// queue up a bunch of txns
+// 	txn.SetChaos(txn.Chaos{
+// 		KillChance: 1,
+// 		Breakpoint: "set-applying",
+// 	})
+// 	defer txn.SetChaos(txn.Chaos{})
+// 	ops := []txn.Op{{
+// 		C:      s.coll.Name,
+// 		Id:     0,
+// 		Update: bson.M{"$set": bson.M{"foo": "baz"}},
+// 	}}
+// 	for i := 0; i < 50; i++ {
+// 		c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
+// 	}
+// 	var result bson.M
+// 	err = s.coll.FindId(0).One(&result)
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(result["foo"], gc.Equals, "bar")
+// 	c.Check(result["txn-queue"], gc.HasLen, 51)
+// }
+// 
+// func (s *InvalidTxnReferenceCleanerSuite) TestTrimNotLongEnough(c *gc.C) {
+// 	s.createDocWith51Txns(c)
+// 	err := TrimLongTransactionQueues(s.txns, 100, "txns.stash", "coll")
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	// untouched
+// 	var result bson.M
+// 	err = s.coll.FindId(0).One(&result)
+// 	c.Check(result["foo"], gc.Equals, "bar")
+// 	c.Check(result["txn-queue"], gc.HasLen, 51)
+// }
+// 
+// func (s *InvalidTxnReferenceCleanerSuite) TestTrimmedSingleDoc(c *gc.C) {
+// 	s.createDocWith51Txns(c)
+// 	trimmer := &LongTxnTrimmer{
+// 		txns:         s.txns,
+// 		longTxnSize:  50,
+// 		txnBatchSize: 5,
+// 	}
+// 	count, err := s.txns.Count()
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(count, gc.Equals, 51)
+// 	err = trimmer.Trim([]string{s.coll.Name})
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	// All of the Prepared but not completed txns should be removed
+// 	var result bson.M
+// 	err = s.coll.FindId(0).One(&result)
+// 	c.Check(result["foo"], gc.Equals, "bar")
+// 	c.Check(result["txn-queue"], gc.HasLen, 1)
+// 	c.Check(trimmer.docCleanupCount, gc.Equals, 1)
+// 	count, err = s.txns.Count()
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(count, gc.Equals, 1)
+// }
+// 
+// func (s *InvalidTxnReferenceCleanerSuite) createMultiDocTxns(c *gc.C) {
+// 	err := s.runner.Run([]txn.Op{{
+// 		C:      s.coll.Name,
+// 		Id:     0,
+// 		Insert: bson.M{"foo": "bar"},
+// 	}}, "", nil)
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	err = s.runner.Run([]txn.Op{{
+// 		C:      s.coll.Name,
+// 		Id:     1,
+// 		Insert: bson.M{"foo": "boing"},
+// 	}}, "", nil)
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	// queue up a bunch of txns
+// 	txn.SetChaos(txn.Chaos{
+// 		KillChance: 1,
+// 		Breakpoint: "set-applying",
+// 	})
+// 	defer txn.SetChaos(txn.Chaos{})
+// 	ops := []txn.Op{{
+// 		C:      s.coll.Name,
+// 		Id:     0,
+// 		Update: bson.M{"$set": bson.M{"foo": "baz"}},
+// 	}, {
+// 		C:      s.coll.Name,
+// 		Id:     1,
+// 		Update: bson.M{"$set": bson.M{"foo": "bling"}},
+// 	}}
+// 	for i := 0; i < 50; i++ {
+// 		c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
+// 	}
+// 	var result bson.M
+// 	err = s.coll.FindId(0).One(&result)
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(result["foo"], gc.Equals, "bar")
+// 	c.Check(result["txn-queue"], gc.HasLen, 51)
+// 	err = s.coll.FindId(1).One(&result)
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(result["foo"], gc.Equals, "boing")
+// 	c.Check(result["txn-queue"], gc.HasLen, 51)
+// }
+// 
+// func (s *InvalidTxnReferenceCleanerSuite) TestTrimMultiDoc(c *gc.C) {
+// 	s.createMultiDocTxns(c)
+// 	trimmer := &LongTxnTrimmer{
+// 		txns:         s.txns,
+// 		longTxnSize:  50,
+// 		txnBatchSize: 13,
+// 	}
+// 	count, err := s.txns.Count()
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(count, gc.Equals, 52)
+// 	err = trimmer.Trim([]string{s.coll.Name})
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	// All of the Prepared but not completed txns should be removed
+// 	var result bson.M
+// 	err = s.coll.FindId(0).One(&result)
+// 	c.Check(result["foo"], gc.Equals, "bar")
+// 	c.Check(result["txn-queue"], gc.HasLen, 1)
+// 	err = s.coll.FindId(1).One(&result)
+// 	c.Check(result["foo"], gc.Equals, "boing")
+// 	c.Check(result["txn-queue"], gc.HasLen, 1)
+// 	c.Check(trimmer.docCleanupCount, gc.Equals, 2)
+// 	count, err = s.txns.Count()
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(count, gc.Equals, 2)
+// }
+// 
+// func (s *InvalidTxnReferenceCleanerSuite) TestTrimMultiDocWithExtras(c *gc.C) {
+// 	s.createMultiDocTxns(c)
+// 	// Now we also include another document that intersect with
+// 	// those documents whose queues are way too long.
+// 	// These transactions should not be removed
+// 	txn.SetChaos(txn.Chaos{
+// 		KillChance: 1,
+// 		Breakpoint: "set-applying",
+// 	})
+// 	defer txn.SetChaos(txn.Chaos{})
+// 	err := s.runner.Run([]txn.Op{{
+// 		C:      s.coll.Name,
+// 		Id:     0,
+// 		Update: bson.M{"$set": bson.M{"baz": "bling"}},
+// 	}, {
+// 		C:      s.coll.Name,
+// 		Id:     4,
+// 		Insert: bson.M{"new": "stuff"},
+// 	}}, "", nil)
+// 	c.Assert(err, gc.Equals, txn.ErrChaos)
+// 	trimmer := &LongTxnTrimmer{
+// 		txns:         s.txns,
+// 		longTxnSize:  50,
+// 		txnBatchSize: 17,
+// 	}
+// 	count, err := s.txns.Count()
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(count, gc.Equals, 53)
+// 	err = trimmer.Trim([]string{s.coll.Name})
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	// All of the Prepared but not completed txns should be removed
+// 	var result bson.M
+// 	err = s.coll.FindId(0).One(&result)
+// 	c.Check(result["foo"], gc.Equals, "bar")
+// 	c.Check(result["txn-queue"], gc.HasLen, 2)
+// 	err = s.coll.FindId(1).One(&result)
+// 	c.Check(result["foo"], gc.Equals, "boing")
+// 	c.Check(result["txn-queue"], gc.HasLen, 1)
+// 	c.Check(trimmer.docCleanupCount, gc.Equals, 2)
+// 	count, err = s.txns.Count()
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(count, gc.Equals, 3)
+// }
+// 
+// func (s *InvalidTxnReferenceCleanerSuite) TestTrimMultiDocWithStash(c *gc.C) {
+// 	stash := s.db.C("txns.stash")
+// 	err := s.runner.Run([]txn.Op{{
+// 		C:      s.coll.Name,
+// 		Id:     0,
+// 		Insert: bson.M{"foo": "bar"},
+// 	}}, "", nil)
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	// queue up a bunch of txns
+// 	txn.SetChaos(txn.Chaos{
+// 		KillChance: 1,
+// 		Breakpoint: "set-applying",
+// 	})
+// 	defer txn.SetChaos(txn.Chaos{})
+// 	ops := []txn.Op{{
+// 		C:      s.coll.Name,
+// 		Id:     0,
+// 		Update: bson.M{"$set": bson.M{"foo": "baz"}},
+// 	}, {
+// 		C:      s.coll.Name,
+// 		Id:     1,
+// 		Insert: bson.M{"new": "stuff"},
+// 	}}
+// 	for i := 0; i < 50; i++ {
+// 		c.Assert(s.runner.Run(ops, "", nil), gc.Equals, txn.ErrChaos)
+// 	}
+// 	var result bson.M
+// 	err = s.coll.FindId(0).One(&result)
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(result["foo"], gc.Equals, "bar")
+// 	c.Check(result["txn-queue"], gc.HasLen, 51)
+// 	err = stash.FindId(bson.D{{"c", s.coll.Name}, {"id", 1}}).One(&result)
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(result["txn-queue"], gc.HasLen, 50)
+// 	trimmer := &LongTxnTrimmer{
+// 		txns:         s.txns,
+// 		longTxnSize:  50,
+// 		txnBatchSize: 13,
+// 		txnsStash:    stash,
+// 	}
+// 	count, err := s.txns.Count()
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(count, gc.Equals, 51)
+// 	err = trimmer.Trim([]string{s.coll.Name})
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	// All of the Prepared but not completed txns should be removed
+// 	err = s.coll.FindId(0).One(&result)
+// 	c.Check(result["foo"], gc.Equals, "bar")
+// 	c.Check(result["txn-queue"], gc.HasLen, 1)
+// 	err = stash.Find(bson.M{"_id.id": 1}).One(&result)
+// 	// All txns that affected this doc have been removed
+// 	c.Check(result["txn-queue"], gc.HasLen, 0)
+// 	c.Check(trimmer.docCleanupCount, gc.Equals, 2)
+// 	count, err = s.txns.Count()
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(count, gc.Equals, 1)
+// }
+// 

--- a/invalidtxnrefs_test.go
+++ b/invalidtxnrefs_test.go
@@ -42,7 +42,7 @@ func (s *InvalidTxnReferenceCleanerSuite) TestNoMissingDoc(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result["foo"], gc.Equals, "bar")
 	c.Check(result["txn-queue"], gc.HasLen, 1)
-	err = CleanupInvalidTxnReferences(s.txns)
+	err = CleanupInvalidTxnReferences(s.db, s.txns)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result["foo"], gc.Equals, "bar")
 	c.Check(result["txn-queue"], gc.HasLen, 1)
@@ -83,7 +83,7 @@ func (s *InvalidTxnReferenceCleanerSuite) TestTxnWithNoDoc(c *gc.C) {
 	var raw rawTransaction
 	c.Assert(s.txns.FindId(oid).One(&raw), jc.ErrorIsNil)
 	c.Check(raw.State, gc.Equals, 2) // prepared
-	err = CleanupInvalidTxnReferences(s.txns)
+	err = CleanupInvalidTxnReferences(s.db, s.txns)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.txns.FindId(oid).One(&raw), jc.ErrorIsNil)
 	c.Check(raw.State, gc.Equals, 1) // preparing

--- a/main.go
+++ b/main.go
@@ -282,8 +282,6 @@ func commandLine() commandLineArgs {
 		"during 'prune' process this many transactions together")
 	flags.IntVar(&pruneSleepTimeMs, "prune-batch-sleep-ms", 0,
 		"during 'prune' sleep this long between batches (reduces load)")
-	// flags.BoolVar(&deleteInvalidTxns, "delete-invalid-txns", false,
-	// 	"if we encounter a transaction that doesn't fit our known issues, delete it anyway")
 	var rawStages string
 	flags.StringVar(&rawStages, "stages", "",
 		"comma separated list of stages to run (default is to run all)")

--- a/main.go
+++ b/main.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"time"
 
-	jujutxn "github.com/juju/txn"
 	"github.com/juju/mgo/v2"
 	"github.com/juju/mgo/v2/txn"
+	jujutxn "github.com/juju/txn"
 )
 
 const txnsC = "txns"
@@ -34,6 +34,7 @@ var trimQueueLength = defaultTrimQueueLength
 var pruneSleepTimeMs = 0
 var maxTxnsToProcess = defaultMaxTxnsToProcess
 var multithreaded = true
+// var deleteInvalidTxns = false
 
 var controllerPrompt = `
 This program should only be used to recover from specific transaction
@@ -277,6 +278,8 @@ func commandLine() commandLineArgs {
 		"during 'prune' process this many transactions together")
 	flags.IntVar(&pruneSleepTimeMs, "prune-batch-sleep-ms", 0,
 		"during 'prune' sleep this long between batches (reduces load)")
+	// flags.BoolVar(&deleteInvalidTxns, "delete-invalid-txns", false,
+	// 	"if we encounter a transaction that doesn't fit our known issues, delete it anyway")
 	var rawStages string
 	flags.StringVar(&rawStages, "stages", "",
 		"comma separated list of stages to run (default is to run all)")

--- a/main.go
+++ b/main.go
@@ -60,14 +60,14 @@ var allStages = []stage{
 		},
 	}, {
 		"purgemissing",
-		"Purge orphaned transactions",
+		"Purge orphaned transactions, should not be run live",
 		func(db *mgo.Database, txns *mgo.Collection) error {
 			collections := getAllPurgeableCollections(db)
 			return PurgeMissing(txns, db.C(txnsStashC), collections...)
 		},
 	}, {
 		"trim",
-		"Trim txn-queues that are longer than trim-queue-length",
+		"Trim txn-queues that are longer than trim-queue-length, should not be run live",
 		func(db *mgo.Database, txns *mgo.Collection) error {
 			collections := getAllPurgeableCollections(db)
 			trimmer := &LongTxnTrimmer{
@@ -80,14 +80,18 @@ var allStages = []stage{
 			return trimmer.Trim(collections)
 		},
 	}, {
+		"invalidreferences",
+		"Handle transactions that aren't referenced by their docs, can be run live",
+		CleanupInvalidTxnReferences,
+	}, {
 		"resume",
-		"Resume incomplete transactions",
+		"Resume incomplete transactions. can be run live",
 		func(db *mgo.Database, txns *mgo.Collection) error {
 			return ResumeAll(txns)
 		},
 	}, {
 		"prune",
-		"Prune finalised transactions",
+		"Prune finalised transactions. can be run live",
 		func(db *mgo.Database, txns *mgo.Collection) error {
 			first := true
 			var totalStats jujutxn.CleanupStats
@@ -134,7 +138,7 @@ var allStages = []stage{
 		},
 	}, {
 		"compact",
-		"Compact database to release disk space (does not compact replicas)",
+		"Compact database to release disk space (does not compact replicas), should not be run live",
 		func(db *mgo.Database, _ *mgo.Collection) error {
 			err := compact(db)
 			if err != nil {


### PR DESCRIPTION
This adds a new stage to mongo `invalidreferences`. This looks for all transactions that are in State 2 (prepared) and then checks to see if 
a) the document exists
b) the transaction is properly labeled in its queue

If either isn't true, it then sets the document back to State 1 (preparing). In simple tests this fixes what we've run into. I can also say that I was at least able to reproduce the rough issues seen in production.

I created the broken transaction by creating a TXN that references a machine document that doesn't exist:
```
> db.txns.insert({"s": 2, "o": [{"c": "machines", "d": "45aa2eab-ecff-42e7-83f1-1cd69a015318:1", "a": "d+", "u": {"$set": {"tools.version": "2.9.8-ubuntu-amd64"}}}], "n": "39825189", "r":[NumberLong(32)]})
```

At this point `juju debug-log -m controller` should show that the Resumer is failing once per minute.

With the stage skipped:
```
root@juju-1c71ae-0:/var/lib/juju# ~ubuntu/mgopurge -skip-stages invalidreferences,compact -password ${pw} -username ${agent}
running stages: [presence purgemissing trim resume prune]
This program should only be used to recover from specific transaction
related problems in a Juju database. Casual use is strongly
discouraged. Irreversible damage may be caused to a Juju deployment
through improper use of this tool.

Aside from limited cases, this program should not be run while Juju
controller machine agents are running.

Ok to proceed? [y/n] y
2021-08-09 21:40:25 INFO  Running stage "presence": Clear presence data. This will be recreated when the controllers restart.
2021-08-09 21:40:25 INFO  Running stage "purgemissing": Purge orphaned transactions, should not be run live
2021-08-09 21:40:25 DEBUG document unitstates/45aa2eab-ecff-42e7-83f1-1cd69a015318:u#ubuntu-lite/0#charm: purging 1 orphaned or invalid txn tokens
2021-08-09 21:40:25 DEBUG tokens: [611194e27ed3bcc9393121bc_c167bcb6]
2021-08-09 21:40:25 INFO  Running stage "trim": Trim txn-queues that are longer than trim-queue-length, should not be run live
2021-08-09 21:40:25 INFO  found 0 transactions and 0 tokens that might be trimmed
2021-08-09 21:40:25 INFO  trimmed 0 docs from 0 tokens (0.000s), removing 0 transactions (0.000s) in 18.610392ms
2021-08-09 21:40:25 INFO  Running stage "resume": Resume incomplete transactions. can be run live
2021-08-09 21:40:25 ERROR failed stage resume: cannot find document {machines 45aa2eab-ecff-42e7-83f1-1cd69a015318:1} for applying transaction 611197377e7774ac1e44fa22_39825189
```

And then with the stage:
```
root@juju-1c71ae-0:/var/lib/juju# ~ubuntu/mgopurge -skip-stages compact -password ${pw} -username ${agent}
running stages: [presence purgemissing trim invalidreferences resume prune]
This program should only be used to recover from specific transaction
related problems in a Juju database. Casual use is strongly
discouraged. Irreversible damage may be caused to a Juju deployment
through improper use of this tool.

Aside from limited cases, this program should not be run while Juju
controller machine agents are running.

Ok to proceed? [y/n] y
2021-08-09 21:40:38 INFO  Running stage "presence": Clear presence data. This will be recreated when the controllers restart.
2021-08-09 21:40:38 INFO  Running stage "purgemissing": Purge orphaned transactions, should not be run live
2021-08-09 21:40:38 INFO  Running stage "trim": Trim txn-queues that are longer than trim-queue-length, should not be run live
2021-08-09 21:40:38 INFO  found 0 transactions and 0 tokens that might be trimmed
2021-08-09 21:40:38 INFO  trimmed 0 docs from 0 tokens (0.000s), removing 0 transactions (0.000s) in 17.563797ms
2021-08-09 21:40:38 INFO  Running stage "invalidreferences": Handle transactions that aren't referenced by their docs, can be run live
2021-08-09 21:40:38 INFO  Transaction "611197377e7774ac1e44fa22_39825189" references a missing document "machines" 45aa2eab-ecff-42e7-83f1-1cd69a015318:1
2021-08-09 21:40:38 INFO  Running stage "resume": Resume incomplete transactions. can be run live
2021-08-09 21:40:38 INFO  Running stage "prune": Prune finalised transactions. can be run live
2021-08-09 21:40:38 DEBUG looking for completed transactions older than 2021-08-09 20:40:38.956790615 +0000 UTC m=-3598.210242064
2021-08-09 21:40:38 DEBUG looking for completed transactions older than 2021-08-09 20:40:38.956790615 +0000 UTC m=-3598.210242064
```

You can see that it did find the bad txn, and it was able to progress it so that 'resume' can do its work.